### PR TITLE
Fix warning warning on variable package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule QuickAlias.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps(),
-     package: package]
+     package: package()]
   end
 
   def application do


### PR DESCRIPTION
Fix for warning: variable "package" does not exist and is being expanded to "package()"