### PR TITLE
Fix warning on loaded_modules

### DIFF
--- a/lib/quick_alias.ex
+++ b/lib/quick_alias.ex
@@ -2,7 +2,7 @@ defmodule QuickAlias do
   defmacro __using__({_, _, atom_module}) do
     module = Module.concat(atom_module)
 
-    loaded_modules
+    loaded_modules()
     |> get_children_of(module)
     |> Enum.map(&build_quoted_alias/1)
     |> build_quoted_block


### PR DESCRIPTION
Fix warning: variable "loaded_modules" does not exist and is being expanded to "loaded_modules()"